### PR TITLE
Fix GitHub Pages asset paths by configuring Vite base path

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -3,6 +3,7 @@ import react from "@vitejs/plugin-react"
 import { defineConfig } from "vite"
 
 export default defineConfig({
+  base: '/VMS/',
   plugins: [react()],
   resolve: {
     alias: {

--- a/index.html
+++ b/index.html
@@ -2,11 +2,11 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="icon" type="image/svg+xml" href="/VMS/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>vessel-management-frontend</title>
-    <script type="module" crossorigin src="/assets/index-BmzTXH6r.js"></script>
-    <link rel="stylesheet" crossorigin href="/assets/index-Dfnvu37B.css">
+    <script type="module" crossorigin src="/VMS/assets/index-BmzTXH6r.js"></script>
+    <link rel="stylesheet" crossorigin href="/VMS/assets/index-Dfnvu37B.css">
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
# Fix GitHub Pages asset paths by configuring Vite base path

## Summary
Fixes the 404 errors preventing the React frontend from loading on GitHub Pages by configuring Vite to use the correct base path (`/VMS/`) for GitHub Pages deployment.

**Root Cause**: GitHub Pages serves user repositories from `https://username.github.io/repo-name/` but the React build was using absolute paths starting with `/` for assets. When the browser tried to load `/assets/index-BmzTXH6r.js`, it looked at `https://ricomail795-prog.github.io/assets/index-BmzTXH6r.js` instead of the correct `https://ricomail795-prog.github.io/VMS/assets/index-BmzTXH6r.js`.

**Solution**: Set `base: '/VMS/'` in Vite config so the build generates asset paths relative to the GitHub Pages subdirectory.

## Review & Testing Checklist for Human
- [ ] **Verify GitHub Pages loads correctly** - After merging, test https://ricomail795-prog.github.io/VMS/ to confirm the React app displays without 404 errors
- [ ] **Test local development still works** - Run `cd frontend && npm run dev` and verify the app loads correctly at localhost:5173
- [ ] **Check deployed app continues working** - Verify https://vessel-management-app-85ll6gia.devinapps.com still loads correctly
- [ ] **Confirm asset paths are correct** - In browser dev tools, verify assets load from `/VMS/assets/` paths on GitHub Pages

### Notes
- The main branch should be used to view the site from GitHub Pages after this fix
- This change affects the Vite build configuration which could have broader implications for all deployments
- Session: https://app.devin.ai/sessions/753ba1ce1eea427abaad1c883e807fa2 | Requested by @ricomail795-prog