### PR TITLE
Implement role-based access control with admin and crew user roles

### DIFF
--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -119,5 +119,38 @@ class InMemoryDatabase:
         if vessel_id:
             return [record for record in self.safety_records.values() if record["vessel_id"] == vessel_id]
         return list(self.safety_records.values())
+    
+    def create_vessel(self, vessel_data: dict) -> dict:
+        vessel_id = self._get_next_id()
+        vessel_data["id"] = vessel_id
+        vessel_data["created_at"] = datetime.now()
+        self.vessels[vessel_id] = vessel_data
+        return vessel_data
+    
+    def create_crew_assignment(self, assignment_data: dict) -> dict:
+        assignment_id = self._get_next_id()
+        assignment_data["id"] = assignment_id
+        self.crew_assignments[assignment_id] = assignment_data
+        return assignment_data
+    
+    def get_crew_assignments(self, user_id: Optional[int] = None, vessel_id: Optional[int] = None) -> List[dict]:
+        assignments = list(self.crew_assignments.values())
+        if user_id:
+            assignments = [a for a in assignments if a["user_id"] == user_id]
+        if vessel_id:
+            assignments = [a for a in assignments if a["vessel_id"] == vessel_id]
+        return assignments
+    
+    def get_user_current_assignment(self, user_id: int) -> Optional[dict]:
+        for assignment in self.crew_assignments.values():
+            if assignment["user_id"] == user_id and assignment["is_active"]:
+                return assignment
+        return None
+    
+    def update_crew_assignment(self, assignment_id: int, assignment_data: dict) -> Optional[dict]:
+        if assignment_id in self.crew_assignments:
+            self.crew_assignments[assignment_id].update(assignment_data)
+            return self.crew_assignments[assignment_id]
+        return None
 
 db = InMemoryDatabase()

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -4,9 +4,11 @@ import { apiClient, User } from '../lib/api';
 interface AuthContextType {
   user: User | null;
   login: (email: string, password: string) => Promise<void>;
-  register: (email: string, password: string, firstName?: string, surname?: string) => Promise<void>;
+  register: (email: string, password: string, firstName?: string, surname?: string, role?: string) => Promise<void>;
   logout: () => void;
   isLoading: boolean;
+  isAdmin: () => boolean;
+  isCrew: () => boolean;
 }
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
@@ -53,13 +55,14 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
     }
   };
 
-  const register = async (email: string, password: string, firstName?: string, surname?: string) => {
+  const register = async (email: string, password: string, firstName?: string, surname?: string, role?: string) => {
     try {
       await apiClient.register({
         email,
         password,
         first_name: firstName,
         surname: surname,
+        role: role || 'crew',
       });
     } catch (error) {
       throw error;
@@ -71,12 +74,22 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
     setUser(null);
   };
 
+  const isAdmin = () => {
+    return user?.role === 'admin';
+  };
+
+  const isCrew = () => {
+    return user?.role === 'crew';
+  };
+
   const value = {
     user,
     login,
     register,
     logout,
     isLoading,
+    isAdmin,
+    isCrew,
   };
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -10,6 +10,7 @@ interface RegisterData {
   password: string;
   first_name?: string;
   surname?: string;
+  role?: string;
 }
 
 interface User {
@@ -112,6 +113,32 @@ class ApiClient {
 
   async getCertificates() {
     return this.request('/certificates');
+  }
+
+  async createVessel(vesselData: any) {
+    return this.request('/vessels', {
+      method: 'POST',
+      body: JSON.stringify(vesselData),
+    });
+  }
+
+  async getCrewAssignments(userId?: number, vesselId?: number) {
+    const params = new URLSearchParams();
+    if (userId) params.append('user_id', userId.toString());
+    if (vesselId) params.append('vessel_id', vesselId.toString());
+    const query = params.toString() ? `?${params.toString()}` : '';
+    return this.request(`/crew-assignments${query}`);
+  }
+
+  async createCrewAssignment(assignmentData: any) {
+    return this.request('/crew-assignments', {
+      method: 'POST',
+      body: JSON.stringify(assignmentData),
+    });
+  }
+
+  async getMyAssignment() {
+    return this.request('/my-assignment');
   }
 
   logout() {

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -1,7 +1,8 @@
 import React, { useState, useEffect } from 'react';
 import { apiClient } from '../lib/api';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../components/ui/card';
-import { Ship, Wrench, Shield } from 'lucide-react';
+import { Ship, Wrench, Shield, User } from 'lucide-react';
+import { useAuth } from '../contexts/AuthContext';
 
 interface DashboardData {
   total_vessels: number;
@@ -14,6 +15,7 @@ interface DashboardData {
 }
 
 const Dashboard: React.FC = () => {
+  const { user, isAdmin, isCrew } = useAuth();
   const [data, setData] = useState<DashboardData | null>(null);
   const [loading, setLoading] = useState(true);
 
@@ -71,7 +73,14 @@ const Dashboard: React.FC = () => {
     <div className="space-y-6">
       <div>
         <h1 className="text-3xl font-bold text-gray-900">Dashboard</h1>
-        <p className="text-gray-600">Overview of your vessel management system</p>
+        <p className="text-gray-600">
+          Welcome to your vessel management system, {user?.first_name || 'User'}
+          {user?.role && (
+            <span className="ml-2 px-2 py-1 bg-blue-100 text-blue-800 text-xs rounded-full">
+              {user.role.charAt(0).toUpperCase() + user.role.slice(1)}
+            </span>
+          )}
+        </p>
       </div>
 
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">

--- a/frontend/src/pages/RegisterPage.tsx
+++ b/frontend/src/pages/RegisterPage.tsx
@@ -11,6 +11,7 @@ const RegisterPage: React.FC = () => {
   const [password, setPassword] = useState('');
   const [firstName, setFirstName] = useState('');
   const [surname, setSurname] = useState('');
+  const [role, setRole] = useState('crew');
   const [error, setError] = useState('');
   const [isLoading, setIsLoading] = useState(false);
   const { register } = useAuth();
@@ -22,7 +23,7 @@ const RegisterPage: React.FC = () => {
     setIsLoading(true);
 
     try {
-      await register(email, password, firstName, surname);
+      await register(email, password, firstName, surname, role);
       navigate('/login');
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Registration failed');
@@ -98,6 +99,20 @@ const RegisterPage: React.FC = () => {
                 required
                 placeholder="Enter your password"
               />
+            </div>
+            <div className="space-y-2">
+              <label htmlFor="role" className="text-sm font-medium">
+                Role
+              </label>
+              <select
+                id="role"
+                value={role}
+                onChange={(e) => setRole(e.target.value)}
+                className="w-full p-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+              >
+                <option value="crew">Crew Member</option>
+                <option value="admin">Administrator</option>
+              </select>
             </div>
             <Button type="submit" className="w-full" disabled={isLoading}>
               {isLoading ? 'Creating Account...' : 'Create Account'}

--- a/frontend/src/pages/Vessels.tsx
+++ b/frontend/src/pages/Vessels.tsx
@@ -2,7 +2,9 @@ import React, { useState, useEffect } from 'react';
 import { apiClient } from '../lib/api';
 import { Card, CardContent, CardHeader, CardTitle } from '../components/ui/card';
 import { Badge } from '../components/ui/badge';
-import { Ship } from 'lucide-react';
+import { Button } from '../components/ui/button';
+import { Ship, Plus, UserCheck } from 'lucide-react';
+import { useAuth } from '../contexts/AuthContext';
 
 interface Vessel {
   id: number;
@@ -18,23 +20,78 @@ interface Vessel {
 }
 
 const Vessels: React.FC = () => {
+  const { isAdmin, isCrew } = useAuth();
   const [vessels, setVessels] = useState<Vessel[]>([]);
   const [loading, setLoading] = useState(true);
+  const [showAddForm, setShowAddForm] = useState(false);
+  const [newVessel, setNewVessel] = useState({
+    name: '',
+    imo_number: '',
+    vessel_type: '',
+    flag_state: '',
+    gross_tonnage: '',
+    length: '',
+    beam: '',
+    year_built: ''
+  });
+
+  const fetchVessels = async () => {
+    try {
+      const vesselData = await apiClient.getVessels();
+      setVessels(vesselData);
+    } catch (error) {
+      console.error('Failed to fetch vessels:', error);
+    } finally {
+      setLoading(false);
+    }
+  };
 
   useEffect(() => {
-    const fetchVessels = async () => {
-      try {
-        const vesselData = await apiClient.getVessels();
-        setVessels(vesselData);
-      } catch (error) {
-        console.error('Failed to fetch vessels:', error);
-      } finally {
-        setLoading(false);
-      }
-    };
-
     fetchVessels();
   }, []);
+
+  const handleAddVessel = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      const vesselData = {
+        ...newVessel,
+        gross_tonnage: newVessel.gross_tonnage ? parseFloat(newVessel.gross_tonnage) : undefined,
+        length: newVessel.length ? parseFloat(newVessel.length) : undefined,
+        beam: newVessel.beam ? parseFloat(newVessel.beam) : undefined,
+        year_built: newVessel.year_built ? parseInt(newVessel.year_built) : undefined,
+      };
+      await apiClient.createVessel(vesselData);
+      setShowAddForm(false);
+      setNewVessel({
+        name: '',
+        imo_number: '',
+        vessel_type: '',
+        flag_state: '',
+        gross_tonnage: '',
+        length: '',
+        beam: '',
+        year_built: ''
+      });
+      fetchVessels();
+    } catch (error) {
+      console.error('Failed to create vessel:', error);
+    }
+  };
+
+  const handleAssignToVessel = async (vesselId: number) => {
+    try {
+      await apiClient.createCrewAssignment({
+        vessel_id: vesselId,
+        position: 'Crew Member',
+        start_date: new Date().toISOString().split('T')[0],
+        is_active: true
+      });
+      alert('Successfully assigned to vessel!');
+    } catch (error) {
+      console.error('Failed to assign to vessel:', error);
+      alert('Failed to assign to vessel');
+    }
+  };
 
   if (loading) {
     return <div className="text-center">Loading vessels...</div>;
@@ -45,9 +102,114 @@ const Vessels: React.FC = () => {
       <div className="flex items-center justify-between">
         <div>
           <h1 className="text-3xl font-bold text-gray-900">Vessels</h1>
-          <p className="text-gray-600">Manage your fleet of vessels</p>
+          <p className="text-gray-600">
+            {isAdmin() ? 'Manage your fleet of vessels' : 'View available vessels and assignments'}
+          </p>
         </div>
+        {isAdmin() && (
+          <Button onClick={() => setShowAddForm(true)} className="flex items-center gap-2">
+            <Plus className="h-4 w-4" />
+            Add Vessel
+          </Button>
+        )}
       </div>
+
+      {showAddForm && (
+        <Card>
+          <CardHeader>
+            <CardTitle>Add New Vessel</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <form onSubmit={handleAddVessel} className="space-y-4">
+              <div className="grid grid-cols-2 gap-4">
+                <div>
+                  <label className="block text-sm font-medium mb-1">Vessel Name *</label>
+                  <input
+                    type="text"
+                    required
+                    value={newVessel.name}
+                    onChange={(e) => setNewVessel({...newVessel, name: e.target.value})}
+                    className="w-full p-2 border rounded-md"
+                  />
+                </div>
+                <div>
+                  <label className="block text-sm font-medium mb-1">IMO Number</label>
+                  <input
+                    type="text"
+                    value={newVessel.imo_number}
+                    onChange={(e) => setNewVessel({...newVessel, imo_number: e.target.value})}
+                    className="w-full p-2 border rounded-md"
+                  />
+                </div>
+                <div>
+                  <label className="block text-sm font-medium mb-1">Vessel Type *</label>
+                  <input
+                    type="text"
+                    required
+                    value={newVessel.vessel_type}
+                    onChange={(e) => setNewVessel({...newVessel, vessel_type: e.target.value})}
+                    className="w-full p-2 border rounded-md"
+                  />
+                </div>
+                <div>
+                  <label className="block text-sm font-medium mb-1">Flag State *</label>
+                  <input
+                    type="text"
+                    required
+                    value={newVessel.flag_state}
+                    onChange={(e) => setNewVessel({...newVessel, flag_state: e.target.value})}
+                    className="w-full p-2 border rounded-md"
+                  />
+                </div>
+                <div>
+                  <label className="block text-sm font-medium mb-1">Gross Tonnage</label>
+                  <input
+                    type="number"
+                    value={newVessel.gross_tonnage}
+                    onChange={(e) => setNewVessel({...newVessel, gross_tonnage: e.target.value})}
+                    className="w-full p-2 border rounded-md"
+                  />
+                </div>
+                <div>
+                  <label className="block text-sm font-medium mb-1">Length (m)</label>
+                  <input
+                    type="number"
+                    step="0.1"
+                    value={newVessel.length}
+                    onChange={(e) => setNewVessel({...newVessel, length: e.target.value})}
+                    className="w-full p-2 border rounded-md"
+                  />
+                </div>
+                <div>
+                  <label className="block text-sm font-medium mb-1">Beam (m)</label>
+                  <input
+                    type="number"
+                    step="0.1"
+                    value={newVessel.beam}
+                    onChange={(e) => setNewVessel({...newVessel, beam: e.target.value})}
+                    className="w-full p-2 border rounded-md"
+                  />
+                </div>
+                <div>
+                  <label className="block text-sm font-medium mb-1">Year Built</label>
+                  <input
+                    type="number"
+                    value={newVessel.year_built}
+                    onChange={(e) => setNewVessel({...newVessel, year_built: e.target.value})}
+                    className="w-full p-2 border rounded-md"
+                  />
+                </div>
+              </div>
+              <div className="flex gap-2">
+                <Button type="submit">Add Vessel</Button>
+                <Button type="button" variant="outline" onClick={() => setShowAddForm(false)}>
+                  Cancel
+                </Button>
+              </div>
+            </form>
+          </CardContent>
+        </Card>
+      )}
 
       {vessels.length === 0 ? (
         <Card>
@@ -106,6 +268,18 @@ const Vessels: React.FC = () => {
                     </div>
                   )}
                 </div>
+                {isCrew() && (
+                  <div className="pt-2 border-t">
+                    <Button 
+                      onClick={() => handleAssignToVessel(vessel.id)}
+                      className="w-full flex items-center gap-2"
+                      size="sm"
+                    >
+                      <UserCheck className="h-4 w-4" />
+                      Assign to This Vessel
+                    </Button>
+                  </div>
+                )}
               </CardContent>
             </Card>
           ))}


### PR DESCRIPTION
- Add UserRole enum (ADMIN, CAPTAIN, CREW, MANAGER) to backend models
- Implement role-based authentication decorators (require_role, require_admin, require_admin_or_manager)
- Add vessel creation and crew assignment endpoints with role-based permissions
- Update frontend AuthContext with isAdmin() and isCrew() helpers
- Add role selection dropdown to registration page
- Implement role-based UI in Vessels page:
  - Admin users: can create vessels with 'Add Vessel' button and form
  - Crew users: can assign themselves to vessels with 'Assign to This Vessel' button
- Add personalized dashboard with role badges
- Update API client with vessel creation and crew assignment methods
- Use environment variable for SECRET_KEY (no hardcoded secrets)

Admin users can now add vessels and manage the system while crew users can use the site and assign themselves to vessels. All role-based permissions are enforced on both backend and frontend.